### PR TITLE
``batch['text']`` adds ``[self.mapping_task[task_name]]`` twice

### DIFF
--- a/cldm/cldm_unicontrol.py
+++ b/cldm/cldm_unicontrol.py
@@ -436,7 +436,7 @@ class ControlLDM(LatentDiffusion):
         batch['txt'] = batch['txt'] + [self.mapping_task[task_name]]
         
         x, c_all = super().get_input(batch, self.first_stage_key, *args, **kwargs)
-        c, c_task = c_all[:BS,:,:], c_all[BS:,:1,:]
+        c, c_task = c_all[:BS,:,:], c_all[BS:BS+1,:1,:]
         control = batch[self.control_key]
         if bs is not None:
             control = control[:bs]

--- a/cldm/cldm_unicontrol_v11.py
+++ b/cldm/cldm_unicontrol_v11.py
@@ -436,7 +436,7 @@ class ControlLDM(LatentDiffusion):
         batch['txt'] = batch['txt'] + [self.mapping_task[task_name]]
         
         x, c_all = super().get_input(batch, self.first_stage_key, *args, **kwargs)
-        c, c_task = c_all[:BS,:,:], c_all[BS:,:1,:]
+        c, c_task = c_all[:BS,:,:], c_all[BS:BS+1,:1,:]
         control = batch[self.control_key]
         if bs is not None:
             control = control[:bs]


### PR DESCRIPTION
function [``log_images``](https://github.com/lighten001/UniControl/blob/472c6cd347df2d2bccba3875d66d27946e847290/cldm/cldm.py#L366) will call ``get_input`` (which is the second time be called) on train batch end
```python
z, c = self.get_input(batch, self.first_stage_key, bs=N)
```
so ``batch['text']`` will add ``[self.mapping_task[task_name]]`` twice
```python
batch['txt'] = batch['txt'] + [self.mapping_task[task_name]]
```
the ``c_task`` should be ``c_all[BS:BS+1,:1,:]`` to avoid the two same task prompt